### PR TITLE
Update readme with correct extension name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,10 +42,10 @@ In either your workspace or user settings add the following. It's generally best
 {
 	"xo.format.enable": true,
 	"[javascript]": {
-		"editor.defaultFormatter": "spence-s.linter-xo"
+		"editor.defaultFormatter": "samverschueren.linter-xo"
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "spence-s.linter-xo"
+		"editor.defaultFormatter": "samverschueren.linter-xo"
 	}
 }
 ```


### PR DESCRIPTION
Changes back to correct extension name `samverschueren.linter-xo` in readme.
