### PR TITLE
feat: allow for multiple languages

### DIFF
--- a/client/extension.js
+++ b/client/extension.js
@@ -9,6 +9,7 @@ const {
 const isSANB = require('is-string-and-not-blank');
 
 let client;
+let validate;
 
 const AllFixesRequest = {
 	type: new RequestType('textDocument/xo/allFixes')
@@ -43,17 +44,17 @@ function activate(context) {
 		}
 	};
 
+	validate = JSON.stringify(xoOptions.get('validate'));
+	const documentSelector = [];
+	for (const language of xoOptions.get('validate')) {
+		documentSelector.push(
+			{language, scheme: 'file'},
+			{language, scheme: 'untitled'}
+		);
+	}
+
 	const clientOptions = {
-		documentSelector: [
-			{language: 'javascript', scheme: 'file'},
-			{language: 'javascript', scheme: 'untitled'},
-			{language: 'javascriptreact', scheme: 'file'},
-			{language: 'javascriptreact', scheme: 'untitled'},
-			{language: 'typescript', scheme: 'file'},
-			{language: 'typescript', scheme: 'untitled'},
-			{language: 'typescriptreact', scheme: 'file'},
-			{language: 'typescriptreact', scheme: 'untitled'}
-		],
+		documentSelector,
 		synchronize: {
 			configurationSection: 'xo',
 			fileEvents: [
@@ -78,6 +79,13 @@ function activate(context) {
 			client.outputChannel.show();
 		})
 	);
+
+	vscode.workspace.onDidChangeConfiguration(() => {
+		const xoOptions = vscode.workspace.getConfiguration('xo');
+		if (validate !== JSON.stringify(xoOptions.get('validate'))) {
+			vscode.commands.executeCommand('workbench.action.reloadWindow');
+		}
+	});
 
 	const statusBar = vscode.window.createStatusBarItem('xoStatusBarItem', 2, 0);
 	statusBar.text = 'XO';

--- a/package.json
+++ b/package.json
@@ -90,6 +90,20 @@
 					],
 					"default": null,
 					"description": "Absolute path to a node binary to run the xo server, defaults to VSCode's internally bundled node version."
+				},
+				"xo.validate": {
+					"scope": "resource",
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [
+						"javascript",
+						"javascriptreact",
+						"typescript",
+						"typescriptreact"
+					],
+					"description": "An array of languages with which to activate the plugin. Defaults: [ \"javascript\", \"javascriptreact\", \"typescript\", \"typescriptreact\" ]"
 				}
 			}
 		},

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,22 @@ To use: pull up the command pallete (usually `F1` or `Ctrl + Shift + P`) and cho
 
 ![](media/fix.gif)
 
+## Additional Languages
+
+By default, the XO extension is configured to activate for Javascript, Javascript + React, Typescript, and Typescript + React. You may add more languages in the VS Code Settings. For example, to add Vue, you could do the following:
+
+```json
+{
+	"xo.validate": [
+		"javascript",
+		"javascriptreact",
+		"typescript",
+		"typescriptreact",
+		"vue"
+	]
+}
+```
+
 ## Settings
 
 Enable the linter in the VS Code Settings, this is on by default.


### PR DESCRIPTION
Allows for a user to select additional languages for the XO extension to be activated. This is especially useful for people, like me, using Vue, and other non-standard options.