### PR TITLE
fix: error when docs field is missing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -707,7 +707,7 @@ class Linter {
 				typeof rulesMeta[diagnostic.code] === 'object'
 			) {
 				diagnostic.codeDescription = {
-					href: rulesMeta[diagnostic.code].docs.url
+					href: rulesMeta[diagnostic.code].docs?.url
 				};
 			} else {
 				try {


### PR DESCRIPTION
Allow using rules which have missing `docs` field, for example in [SonarJS](https://github.com/SonarSource/SonarJS/blob/293e62f81fb328e816ac66198682f700612c666d/eslint-bridge/src/linting/eslint/rules/deprecation.ts#L29-L33).

Before:
Trying to use https://github.com/un-ts/eslint-plugin-sonar would throw errors upon initial loading.

After:
All rules from `eslint-plugin-sonar` are loading fine.