### PR TITLE
Fix: Send filename option when calling lintText

### DIFF
--- a/server/get-lint-results.js
+++ b/server/get-lint-results.js
@@ -26,6 +26,7 @@ async function getLintResults(document, {contents} = {}) {
 
 	// set the options needed for internal xo config resolution
 	options.cwd = folderFsPath;
+	options.filename = documentFsPath;
 	options.filePath = documentFsPath;
 
 	let report;


### PR DESCRIPTION
Using the plugin (if xo config contains "ignores") can give this error:

The `ignores` option requires the `filename` option to be defined.

The options.filename was removed in v3.12.0, this just adds it back in (in the one place I found)